### PR TITLE
Replace cookie consent with GDPR-compliant banner and add privacy policy

### DIFF
--- a/content/privacy.md
+++ b/content/privacy.md
@@ -1,13 +1,75 @@
 ---
 title: Privacy Policy
 date: "2018-06-28T00:00:00+01:00"
-draft: true
+draft: false
 share: false
 
-# Optional header image (relative to `static/img/` folder).
 header:
   caption: ""
   image: ""
 ---
 
-...
+## 1. Overview
+
+This website is operated by Kay Rottmann. Protecting your personal data is important to us. This privacy policy explains what data we collect, why we collect it, and how we handle it.
+
+## 2. Hosting
+
+This website is hosted on GitHub Pages. When you visit this site, GitHub may collect technical data such as your IP address in server logs. For details, see [GitHub's Privacy Statement](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement).
+
+## 3. Cookies
+
+This website uses cookies. Cookies are small text files stored on your device by your browser. We use the following categories of cookies:
+
+### Strictly Necessary Cookies
+
+These cookies are required for the website to function properly. They include the cookie that stores your cookie consent preference. These cookies cannot be disabled.
+
+| Cookie | Purpose | Duration |
+|--------|---------|----------|
+| `cc_cookie` | Stores your cookie consent preferences | 6 months |
+
+### Analytics Cookies (optional, requires your consent)
+
+With your consent, we use Google Analytics 4 (GA4) to understand how visitors use our website. Google Analytics sets the following cookies:
+
+| Cookie | Purpose | Duration |
+|--------|---------|----------|
+| `_ga` | Distinguishes unique users | 2 years |
+| `_ga_*` | Maintains session state | 2 years |
+| `_gid` | Distinguishes unique users | 24 hours |
+
+Google Analytics collects data such as pages visited, time spent on pages, and general geographic location (country/city level). This data is processed in aggregated form and cannot be used to identify you personally.
+
+For more information, see [Google's Privacy Policy](https://policies.google.com/privacy) and [how Google uses data from partner sites](https://policies.google.com/technologies/partner-sites).
+
+## 4. Google Tag Manager
+
+This website uses Google Tag Manager (GTM) to manage website tags. GTM itself does not collect personal data. However, tags deployed through GTM (such as Google Analytics) may collect data as described above. GTM is only used to manage and deploy these tags.
+
+## 5. Consent
+
+When you first visit this website, a cookie consent banner is displayed. You can:
+
+- **Accept all cookies**: Enables analytics cookies in addition to necessary cookies.
+- **Reject non-essential cookies**: Only strictly necessary cookies are used.
+- **Manage preferences**: Choose individually which cookie categories to allow.
+
+You can change your cookie preferences at any time by clearing your browser cookies and revisiting the site.
+
+## 6. Your Rights
+
+Under the GDPR, you have the right to:
+
+- Access the personal data we hold about you
+- Request correction or deletion of your data
+- Object to or restrict the processing of your data
+- Data portability
+
+To exercise these rights, please contact us at the email address provided on this website.
+
+## 7. Changes to This Policy
+
+We may update this privacy policy from time to time. Any changes will be posted on this page.
+
+*Last updated: March 2026*

--- a/themes/academia/layouts/partials/site_head.html
+++ b/themes/academia/layouts/partials/site_head.html
@@ -33,58 +33,92 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','GTM-KK862N76');</script>
 
-<!-- 4. Load Cookie Consent CSS/JS (Osano Open Source version) -->
-<link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.1.1/cookieconsent.min.css" />
-<script src="https://cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.1.1/cookieconsent.min.js"></script>
+<!-- 4. Load Cookie Consent v3 (Orestbida) -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/vanilla-cookieconsent@3.0.1/dist/cookieconsent.css">
+<script defer src="https://cdn.jsdelivr.net/npm/vanilla-cookieconsent@3.0.1/dist/cookieconsent.umd.js"></script>
 
-<!-- 5. Configure Banner & Link to Consent Mode -->
+<!-- 5. Configure GDPR-compliant Consent Banner -->
 <script>
-window.addEventListener("load", function(){
-window.cookieconsent.initialise({
-  "palette": {
-    "popup": { "background": "#252e39" },
-    "button": { "background": "#14a7d0" }
-  },
-  "type": "opt-in", // REQUIRED: blocks cookies until accepted
-  "content": {
-    "message": "This website uses cookies to ensure you get the best experience.",
-    "dismiss": "Decline",
-    "allow": "Allow Cookies"
-  },
-  // EVENT: Triggered when user clicks "Allow"
-  onInitialise: function (status) {
-    var type = this.options.type;
-    var didConsent = this.hasConsented();
-    if (type == 'opt-in' && didConsent) {
-      updateGTMConsent('granted');
-    }
-  },
-  onStatusChange: function(status, chosenBefore) {
-    var type = this.options.type;
-    var didConsent = this.hasConsented();
-    if (type == 'opt-in' && didConsent) {
-      updateGTMConsent('granted');
-    } else {
-      updateGTMConsent('denied');
-    }
-  }
-})});
+document.addEventListener('DOMContentLoaded', function() {
+  if (typeof CookieConsent === 'undefined') return;
 
-// Helper function to update GTM Consent Mode
-function updateGTMConsent(state) {
-  gtag('consent', 'update', {
-    'ad_storage': state,
-    'ad_user_data': state,
-    'ad_personalization': state,
-    'analytics_storage': state
+  function updateConsent() {
+    var analyticsGranted = CookieConsent.acceptedCategory('analytics');
+    gtag('consent', 'update', {
+      'analytics_storage': analyticsGranted ? 'granted' : 'denied',
+      'ad_storage': 'denied',
+      'ad_user_data': 'denied',
+      'ad_personalization': 'denied'
+    });
+    window.dataLayer.push({
+      'event': 'consent_update',
+      'analytics_granted': analyticsGranted
+    });
+  }
+
+  CookieConsent.run({
+    guiOptions: {
+      consentModal: {
+        layout: 'box',
+        position: 'bottom left'
+      }
+    },
+    categories: {
+      necessary: {
+        enabled: true,
+        readOnly: true
+      },
+      analytics: {
+        autoClear: {
+          cookies: [
+            { name: /^_ga/ },
+            { name: '_gid' }
+          ]
+        }
+      }
+    },
+    onFirstConsent: function() { updateConsent(); },
+    onConsent: function() { updateConsent(); },
+    onChange: function() { updateConsent(); },
+    language: {
+      default: 'en',
+      translations: {
+        en: {
+          consentModal: {
+            title: 'This website uses cookies',
+            description: 'We use essential cookies to make this site work. With your consent, we also use analytics cookies (Google Analytics) to understand how you interact with our site in order to improve it. You can accept all cookies, reject non-essential cookies, or manage your preferences individually. For more details, see our <a href="/privacy">Privacy Policy</a>.',
+            acceptAllBtn: 'Accept all',
+            acceptNecessaryBtn: 'Reject non-essential',
+            showPreferencesBtn: 'Manage preferences'
+          },
+          preferencesModal: {
+            title: 'Cookie Preferences',
+            acceptAllBtn: 'Accept all',
+            acceptNecessaryBtn: 'Reject non-essential',
+            savePreferencesBtn: 'Save preferences',
+            closeIconLabel: 'Close',
+            sections: [
+              {
+                title: 'Cookie Usage',
+                description: 'We use cookies to ensure the basic functionality of this website and to enhance your experience. You can choose which categories of cookies to allow below. For details on each category and the specific cookies used, please refer to our <a href="/privacy">Privacy Policy</a>.'
+              },
+              {
+                title: 'Strictly Necessary Cookies',
+                description: 'These cookies are essential for the website to function properly. They enable basic features such as remembering your cookie consent preference. These cookies do not store any personally identifiable information and cannot be disabled.',
+                linkedCategory: 'necessary'
+              },
+              {
+                title: 'Analytics Cookies',
+                description: 'These cookies help us understand how visitors interact with our website by collecting and reporting information anonymously. We use Google Analytics (GA4), which sets cookies such as _ga and _gid to distinguish unique users and track page views. This data helps us improve our site. The collected data is processed in aggregated form.',
+                linkedCategory: 'analytics'
+              }
+            ]
+          }
+        }
+      }
+    }
   });
-  
-  // Push a custom event to GTM (optional, but useful for triggers)
-  window.dataLayer.push({
-    'event': 'consent_update',
-    'consent_status': state
-  });
-}
+});
 </script>
   
   <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
- Replace basic Osano cookieconsent2 with Orestbida cookieconsent v3 which supports per-category consent and a preferences modal
- Two consent categories: "Strictly Necessary" (always on) and "Analytics" (opt-in, controls GA4 cookies)
- Banner explains what cookies are used and why, with three options: "Accept all", "Reject non-essential", and "Manage preferences"
- Preferences modal shows detailed descriptions per category
- Consent updates wired to gtag consent mode (analytics_storage)
- Analytics cookies (_ga, _gid) auto-cleared when consent is revoked
- Links to privacy policy from both the banner and preferences modal
- Enable privacy.md (was draft) with template covering cookies, GA4, GTM, hosting, consent mechanism, and GDPR rights

https://claude.ai/code/session_01JBoGXdSV2SPqZWnPgarbvM